### PR TITLE
refactor: streaming default open;improved streaming setting logic

### DIFF
--- a/src/cli/deepseek_cli.py
+++ b/src/cli/deepseek_cli.py
@@ -35,7 +35,7 @@ except ImportError:
     
 
 class DeepSeekCLI:
-    def __init__(self, *, stream: bool = False):
+    def __init__(self, *, stream: bool = True):
         self.api_client = APIClient()
         self.chat_handler = ChatHandler(stream=stream)
         self.command_handler = CommandHandler(self.api_client, self.chat_handler)
@@ -153,11 +153,22 @@ def parse_arguments():
                         help="Specify the model to use (deepseek-chat, deepseek-coder, deepseek-reasoner)")
     parser.add_argument("-r", "--raw", action="store_true", help="Output raw response without token usage information")
     parser.add_argument("-s", "--stream", action="store_true", help="Enable stream mode")
+    parser.add_argument("--no-stream", action="store_true", help="Disable stream mode")
     return parser.parse_args()
 
 def main():
     args = parse_arguments()
-    cli = DeepSeekCLI(stream=args.stream)
+    
+    # Determine stream mode based on command line arguments
+    if args.no_stream:
+        stream_mode = False
+    elif args.stream:
+        stream_mode = True
+    else:
+        # Use default value from class (which is now True)
+        stream_mode = True
+    
+    cli = DeepSeekCLI(stream=stream_mode)
 
     # Check if running in inline mode
     if args.query:

--- a/src/handlers/chat_handler.py
+++ b/src/handlers/chat_handler.py
@@ -36,7 +36,7 @@ except ImportError:
     from src.utils.version_checker import check_version
 
 class ChatHandler:
-    def __init__(self, *, stream: bool = False):
+    def __init__(self, *, stream: bool = True):
         self.messages = []
         self.model = "deepseek-chat"
         self.stream = stream


### PR DESCRIPTION
Streaming default open. I also improved the streaming setting logic

流式传输现在默认开启,我同时也优化了一下流式传输设置的代码逻辑

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Streaming is now enabled by default for CLI interactions and chat responses, delivering real-time output without additional flags.
  * Added a --no-stream flag to easily disable streaming when desired.
  * Argument parsing updated to support the new flag.
  * Precedence clarified: if both --stream and --no-stream are provided, streaming is disabled.
  * Users can still explicitly enable streaming with --stream, but no flag is needed for streaming by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->